### PR TITLE
Fix: Automatische Weiterleitung für alle /sites/-Seiten erlaubt

### DIFF
--- a/frontend/js/onlyAdminAccess.js
+++ b/frontend/js/onlyAdminAccess.js
@@ -4,12 +4,12 @@ document.addEventListener("DOMContentLoaded", () => {
       .then(data => {
         if (!data.user || data.user.role !== "admin") {
           alert("Zugriff verweigert. Nur für Administratoren.");
-          window.location.href = "../index.html";
+          window.location.href = "index.html";
         }
       })
       .catch(err => {
         console.error("⚠️ Session-Check fehlgeschlagen:", err);
-        window.location.href = "../index.html";
+        window.location.href = "index.html";
       });
   });
   

--- a/frontend/js/userAuthorization.js
+++ b/frontend/js/userAuthorization.js
@@ -141,6 +141,8 @@ if (rememberedLogin
   && !currentPage.includes("adminPanel.html")
   && !currentPage.includes("userRegistration.html")
   && !currentPage.includes("userLogin.html")
+  && !currentPage.includes("/sites/")
+  && !currentPage.includes("/admin/")
 ) {
   try {
     const user = JSON.parse(rememberedLogin);


### PR DESCRIPTION
+ onlyAdminAccess Weiterleitung korregiert

- Automatische Weiterleitung in userAuthorization.js angepasst:
  Alle Seiten innerhalb des Ordners "/sites/" sind jetzt generell erlaubt und
  führen nicht mehr zur ungewollten Weiterleitung auf die index-Seite zurück.

-Außerdem in onlyAdminAccess wurde die Weiterleitung "../index.html" eingestellt was zu eine Ebenen Fehler war, nun wurde es korregiert mit "index.html"

- Verbessert die Wartbarkeit, da nicht mehr jede Seite explizit erwähnt werden muss.
